### PR TITLE
Fix case of filenames in #include directives

### DIFF
--- a/CNCUNO.ino
+++ b/CNCUNO.ino
@@ -15,13 +15,13 @@
 *
 *****************************************************************************************/
 
-#include "stepper.h"
+#include "Stepper.h"
 #include "LCD_Stuff.h"
 #include <math.h>
 #include <avr/eeprom.h>
 #include "switch.h"
 #include "EncoderPolling.h"
-#include <sd.h>
+#include <SD.h>
 
 #define ENCODER_USE_INTERRUPTS
 


### PR DESCRIPTION
Incorrect filename case causes compilation to fail:
```
C:\Users\per\Desktop\CNCUNO\CNCUNO.ino:18:21: fatal error: stepper.h: No such file or directory
```